### PR TITLE
Adapt to XCode 9.1 and suppress some warning

### DIFF
--- a/HaskellSpriteKit.xcodeproj/project.pbxproj
+++ b/HaskellSpriteKit.xcodeproj/project.pbxproj
@@ -260,7 +260,7 @@
 					};
 					E791CF6219FA595A00DECDC4 = {
 						CreatedOnToolsVersion = 6.1;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0910;
 					};
 				};
 			};
@@ -528,11 +528,9 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"/Users/chak/Code/HaskellForMac/HaskellForMac/BinaryFrameworks/$(CONFIGURATION)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				FRAMEWORK_VERSION = A;
+				HEADER_SEARCH_PATHS = "/Library/Frameworks/GHC.framework/Versions/Current/usr/lib/ghc-8.0.2/include/";
 				INFOPLIST_FILE = HaskellSpriteKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks @executable_path/../Frameworks/GHC.framework/Versions/Current/usr/lib/ghc";
@@ -561,11 +559,9 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"/Users/chak/Code/HaskellForMac/HaskellForMac/BinaryFrameworks/$(CONFIGURATION)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				FRAMEWORK_VERSION = A;
+				HEADER_SEARCH_PATHS = "/Library/Frameworks/GHC.framework/Versions/Current/usr/lib/ghc-8.0.2/include/";
 				INFOPLIST_FILE = HaskellSpriteKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks @executable_path/../Frameworks/GHC.framework/Versions/Current/usr/lib/ghc";
@@ -591,7 +587,6 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
-					/Users/chak/Code/HaskellForMac/HaskellForMac/BinaryFrameworks/Debug,
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -601,7 +596,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.justtesting.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -612,13 +608,12 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
-					/Users/chak/Code/HaskellForMac/HaskellForMac/BinaryFrameworks/Debug,
 				);
 				INFOPLIST_FILE = HaskellSpriteKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.justtesting.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/HaskellSpriteKit/spritekit/Graphics/SpriteKit/Scene.hs
+++ b/HaskellSpriteKit/spritekit/Graphics/SpriteKit/Scene.hs
@@ -285,7 +285,7 @@ updateForScene skNode sceneAny currentTime
                                in
                                $(objc [ 'skNode :> ''SKNode, 'worldGravity :> ''Vector, 'worldSpeed :> ''Double{-GFloat-} ] $ void 
                                   [cexp| (
-                                    ((typename SKScene*)skNode).physicsWorld.gravity = *worldGravity,
+                                    (void)(((typename SKScene*)skNode).physicsWorld.gravity = *worldGravity),
                                     ((typename SKScene*)skNode).physicsWorld.speed   = worldSpeed ) |])
 
                          -- Update the reference to the Haskell scene kept by the 'SKScene' object.


### PR DESCRIPTION
These patch used to successfully build HaskellSprite framework in XCode 9.1, some unnecessary search path had been removed, add header search path for ghc-8.0.2.